### PR TITLE
Update aws_networking.tf

### DIFF
--- a/terraform/aws_networking.tf
+++ b/terraform/aws_networking.tf
@@ -58,7 +58,7 @@ resource "aws_customer_gateway" "aws-cgw" {
   ip_address = "${google_compute_address.gcp-vpn-ip.address}"
   type       = "ipsec.1"
   tags {
-    "Name" = "aws-customer-gw"
+    Name = "aws-customer-gw"
   }
 }
 
@@ -79,6 +79,6 @@ resource "aws_vpn_connection" "aws-vpn-connection1" {
   type                = "ipsec.1"
   static_routes_only  = false
   tags {
-    "Name" = "aws-vpn-connection1"
+    Name = "aws-vpn-connection1"
   }
 }


### PR DESCRIPTION
HI,

Just started to work on velostrata, got through below issue, let me know if this is right issue to report

With reference to doc https://cloud.google.com/solutions/automated-network-deployment-multicloud
While running pushd ./terraform && terraform plan && popd > /dev/null  getting below error
nagaraj_goud@cloudshell:~/autonetdeploy-multicloudvpn (nagaraj-goud)$ pushd ./terraform && terraform plan && popd > /dev/null
~/autonetdeploy-multicloudvpn/terraform ~/autonetdeploy-multicloudvpn ~/autonetdeploy-multicloudvpn

Error: Invalid argument name

  on aws_networking.tf line 61, in resource "aws_customer_gateway" "aws-cgw":
  61:     "Name" = "aws-customer-gw"

Argument names must not be quoted.
![image](https://user-images.githubusercontent.com/31380928/71170055-61314a80-2280-11ea-88f4-faf623a207ec.png)


Resolution:   "Name" = "aws-customer-gw" to  Name = "aws-customer-gw" for all the occurences at https://github.com/GoogleCloudPlatform/autonetdeploy-multicloudvpn/blob/master/terraform/aws_networking.tf

Terraform version:

nagaraj_goud@cloudshell:~/autonetdeploy-multicloudvpn/terraform (nagaraj-goud)$ terraform --version
Terraform v0.12.9
+ provider.aws v2.19.0
+ provider.google v2.11.0