### PR TITLE
Update aws_compute.tf

### DIFF
--- a/terraform/aws_compute.tf
+++ b/terraform/aws_compute.tf
@@ -60,7 +60,7 @@ resource "aws_instance" "aws-vm" {
 
   user_data = "${replace("${replace("${file("vm_userdata.sh")}", "<EXT_IP>", "${google_compute_address.gcp-ip.address}")}", "<INT_IP>", "${var.gcp_vm_address}")}"
 
-  tags {
+  tags = {
     Name = "aws-vm-${var.aws_region}"
   }
 }


### PR DESCRIPTION
Came across below error

nagaraj_goud@cloudshell:~/autonetdeploy-multicloudvpn/terraform (nagaraj-goud)$ terraform validate

Error: Unsupported block type

  on aws_compute.tf line 63, in resource "aws_instance" "aws-vm":
  63:   tags{

Blocks of type "tags" are not expected here. Did you mean to define argument
"tags"? If so, use the equals sign to assign it a value.


as per https://github.com/hashicorp/terraform/issues/19325 updated the file