### PR TITLE
Configuration update for Terraform 0.12 compatibility

### DIFF
--- a/terraform/aws_networking.tf
+++ b/terraform/aws_networking.tf
@@ -14,33 +14,32 @@
  * limitations under the License.
  */
 
-
 /*
  * Terraform networking resources for AWS.
  */
 
 resource "aws_vpc" "aws-vpc" {
-  cidr_block = "${var.aws_network_cidr}"
-  enable_dns_support = true
+  cidr_block           = var.aws_network_cidr
+  enable_dns_support   = true
   enable_dns_hostnames = true
-  tags {
+  tags = {
     "Name" = "aws-vpc"
   }
 }
 
 resource "aws_subnet" "aws-subnet1" {
-  vpc_id            = "${aws_vpc.aws-vpc.id}"
-  cidr_block        = "${var.aws_subnet1_cidr}"
+  vpc_id     = aws_vpc.aws-vpc.id
+  cidr_block = var.aws_subnet1_cidr
 
-  tags {
+  tags = {
     Name = "aws-vpn-subnet"
   }
 }
 
 resource "aws_internet_gateway" "aws-vpc-igw" {
-  vpc_id = "${aws_vpc.aws-vpc.id}"
+  vpc_id = aws_vpc.aws-vpc.id
 
-  tags {
+  tags = {
     Name = "aws-vpc-igw"
   }
 }
@@ -50,35 +49,36 @@ resource "aws_internet_gateway" "aws-vpc-igw" {
  */
 
 resource "aws_vpn_gateway" "aws-vpn-gw" {
-  vpc_id = "${aws_vpc.aws-vpc.id}"
+  vpc_id = aws_vpc.aws-vpc.id
 }
 
 resource "aws_customer_gateway" "aws-cgw" {
   bgp_asn    = 65000
-  ip_address = "${google_compute_address.gcp-vpn-ip.address}"
+  ip_address = google_compute_address.gcp-vpn-ip.address
   type       = "ipsec.1"
-  tags {
+  tags = {
     "Name" = "aws-customer-gw"
   }
 }
 
 resource "aws_default_route_table" "aws-vpc" {
-  default_route_table_id = "${aws_vpc.aws-vpc.default_route_table_id}"
+  default_route_table_id = aws_vpc.aws-vpc.default_route_table_id
   route {
-    cidr_block  = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.aws-vpc-igw.id}"
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.aws-vpc-igw.id
   }
   propagating_vgws = [
-    "${aws_vpn_gateway.aws-vpn-gw.id}"
+    aws_vpn_gateway.aws-vpn-gw.id,
   ]
 }
 
 resource "aws_vpn_connection" "aws-vpn-connection1" {
-  vpn_gateway_id      = "${aws_vpn_gateway.aws-vpn-gw.id}"
-  customer_gateway_id = "${aws_customer_gateway.aws-cgw.id}"
+  vpn_gateway_id      = aws_vpn_gateway.aws-vpn-gw.id
+  customer_gateway_id = aws_customer_gateway.aws-cgw.id
   type                = "ipsec.1"
   static_routes_only  = false
-  tags {
+  tags = {
     "Name" = "aws-vpn-connection1"
   }
 }
+

--- a/terraform/aws_outputs.tf
+++ b/terraform/aws_outputs.tf
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-
 /*
  * Terraform output variables for AWS.
  */
 
 output "aws_instance_external_ip" {
-  value = "${aws_eip.aws-ip.public_ip}"
+  value = aws_eip.aws-ip.public_ip
 }
 
 output "aws_instance_internal_ip" {
-  value = "${aws_instance.aws-vm.private_ip}"
+  value = aws_instance.aws-vm.private_ip
 }
+

--- a/terraform/aws_security.tf
+++ b/terraform/aws_security.tf
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 /*
  * Terraform security (firewall) resources for AWS.
  */
@@ -23,7 +22,7 @@
 resource "aws_security_group" "aws-allow-icmp" {
   name        = "aws-allow-icmp"
   description = "Allow icmp access from anywhere"
-  vpc_id      = "${aws_vpc.aws-vpc.id}"
+  vpc_id      = aws_vpc.aws-vpc.id
 
   ingress {
     from_port   = 8
@@ -37,7 +36,7 @@ resource "aws_security_group" "aws-allow-icmp" {
 resource "aws_security_group" "aws-allow-ssh" {
   name        = "aws-allow-ssh"
   description = "Allow ssh access from anywhere"
-  vpc_id      = "${aws_vpc.aws-vpc.id}"
+  vpc_id      = aws_vpc.aws-vpc.id
 
   ingress {
     from_port   = 22
@@ -51,13 +50,13 @@ resource "aws_security_group" "aws-allow-ssh" {
 resource "aws_security_group" "aws-allow-vpn" {
   name        = "aws-allow-vpn"
   description = "Allow all traffic from vpn resources"
-  vpc_id      = "${aws_vpc.aws-vpc.id}"
+  vpc_id      = aws_vpc.aws-vpc.id
 
   ingress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["${var.gcp_subnet1_cidr}"]
+    cidr_blocks = [var.gcp_subnet1_cidr]
   }
 }
 
@@ -65,7 +64,7 @@ resource "aws_security_group" "aws-allow-vpn" {
 resource "aws_security_group" "aws-allow-internet" {
   name        = "aws-allow-internet"
   description = "Allow http traffic from the internet"
-  vpc_id      = "${aws_vpc.aws-vpc.id}"
+  vpc_id      = aws_vpc.aws-vpc.id
 
   ingress {
     from_port   = 80
@@ -81,3 +80,4 @@ resource "aws_security_group" "aws-allow-internet" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+

--- a/terraform/aws_variables.tf
+++ b/terraform/aws_variables.tf
@@ -14,42 +14,42 @@
  * limitations under the License.
  */
 
-
 /*
  * Terraform variable declarations for AWS.
  */
 
-variable aws_credentials_file_path {
+variable "aws_credentials_file_path" {
   description = "Locate the AWS credentials file."
-  type = "string"
+  type        = string
 }
 
-variable aws_region {
+variable "aws_region" {
   description = "Default to Oregon region."
-  default = "us-west-2"
+  default     = "us-west-2"
 }
 
-variable aws_instance_type {
+variable "aws_instance_type" {
   description = "Machine Type. Includes 'Enhanced Networking' via ENA."
-  default = "r4.2xlarge"
+  default     = "r4.2xlarge"
 }
 
-variable aws_disk_image {
+variable "aws_disk_image" {
   description = "Boot disk for gcp_instance_type."
-  default = "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"
+  default     = "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"
 }
 
-variable aws_network_cidr {
+variable "aws_network_cidr" {
   description = "VPC network ip block."
-  default = "172.16.0.0/16"
+  default     = "172.16.0.0/16"
 }
 
-variable aws_subnet1_cidr {
+variable "aws_subnet1_cidr" {
   description = "Subset block from VPC network ip block."
-  default = "172.16.0.0/24"
+  default     = "172.16.0.0/24"
 }
 
-variable aws_vm_address {
+variable "aws_vm_address" {
   description = "Private IP address for AWS VM instance."
-  default = "172.16.0.100"
+  default     = "172.16.0.100"
 }
+

--- a/terraform/gcp_compute.tf
+++ b/terraform/gcp_compute.tf
@@ -14,43 +14,47 @@
  * limitations under the License.
  */
 
-
 /*
  * Terraform compute resources for GCP.
  * Acquire all zones and choose one randomly.
  */
 
 data "google_compute_zones" "available" {
-  region = "${var.gcp_region}"
+  region = var.gcp_region
 }
 
 resource "google_compute_address" "gcp-ip" {
-  name = "gcp-vm-ip-${var.gcp_region}"
-  region = "${var.gcp_region}"
+  name   = "gcp-vm-ip-${var.gcp_region}"
+  region = var.gcp_region
 }
 
 resource "google_compute_instance" "gcp-vm" {
   name         = "gcp-vm-${var.gcp_region}"
-  machine_type = "${var.gcp_instance_type}"
-  zone         = "${data.google_compute_zones.available.names[0]}"
+  machine_type = var.gcp_instance_type
+  zone         = data.google_compute_zones.available.names[0]
 
   boot_disk {
     initialize_params {
-      image = "${var.gcp_disk_image}"
+      image = var.gcp_disk_image
     }
   }
 
   network_interface {
-    subnetwork = "${google_compute_subnetwork.gcp-subnet1.name}"
-    network_ip = "${var.gcp_vm_address}"
+    subnetwork = google_compute_subnetwork.gcp-subnet1.name
+    network_ip = var.gcp_vm_address
 
     access_config {
       # Static IP
-      nat_ip = "${google_compute_address.gcp-ip.address}"
+      nat_ip = google_compute_address.gcp-ip.address
     }
   }
 
   # Cannot pre-load both gcp and aws since that creates a circular dependency.
   # Can pre-populate the AWS IPs to make it easier to run tests.
-  metadata_startup_script = "${replace("${replace("${file("vm_userdata.sh")}", "<EXT_IP>", "${aws_eip.aws-ip.public_ip}")}", "<INT_IP>", "${var.aws_vm_address}")}"
+  metadata_startup_script = replace(
+    replace(file("vm_userdata.sh"), "<EXT_IP>", aws_eip.aws-ip.public_ip),
+    "<INT_IP>",
+    var.aws_vm_address,
+  )
 }
+

--- a/terraform/gcp_networking.tf
+++ b/terraform/gcp_networking.tf
@@ -14,21 +14,20 @@
  * limitations under the License.
  */
 
-
 /*
  * Terraform networking resources for GCP.
  */
 
 resource "google_compute_network" "gcp-network" {
-  name = "gcp-network"
+  name                    = "gcp-network"
   auto_create_subnetworks = "false"
 }
 
 resource "google_compute_subnetwork" "gcp-subnet1" {
   name          = "gcp-subnet1"
-  ip_cidr_range = "${var.gcp_subnet1_cidr}"
-  network       = "${google_compute_network.gcp-network.name}"
-  region        = "${var.gcp_region}"
+  ip_cidr_range = var.gcp_subnet1_cidr
+  network       = google_compute_network.gcp-network.name
+  region        = var.gcp_region
 }
 
 /*
@@ -37,36 +36,36 @@ resource "google_compute_subnetwork" "gcp-subnet1" {
 
 resource "google_compute_address" "gcp-vpn-ip" {
   name   = "gcp-vpn-ip"
-  region = "${var.gcp_region}"
+  region = var.gcp_region
 }
 
 resource "google_compute_vpn_gateway" "gcp-vpn-gw" {
   name    = "gcp-vpn-gw-${var.gcp_region}"
-  network = "${google_compute_network.gcp-network.name}"
-  region  = "${var.gcp_region}"
+  network = google_compute_network.gcp-network.name
+  region  = var.gcp_region
 }
 
 resource "google_compute_forwarding_rule" "fr_esp" {
   name        = "fr-esp"
   ip_protocol = "ESP"
-  ip_address  = "${google_compute_address.gcp-vpn-ip.address}"
-  target      = "${google_compute_vpn_gateway.gcp-vpn-gw.self_link}"
+  ip_address  = google_compute_address.gcp-vpn-ip.address
+  target      = google_compute_vpn_gateway.gcp-vpn-gw.self_link
 }
 
 resource "google_compute_forwarding_rule" "fr_udp500" {
   name        = "fr-udp500"
   ip_protocol = "UDP"
   port_range  = "500-500"
-  ip_address  = "${google_compute_address.gcp-vpn-ip.address}"
-  target      = "${google_compute_vpn_gateway.gcp-vpn-gw.self_link}"
+  ip_address  = google_compute_address.gcp-vpn-ip.address
+  target      = google_compute_vpn_gateway.gcp-vpn-gw.self_link
 }
 
 resource "google_compute_forwarding_rule" "fr_udp4500" {
   name        = "fr-udp4500"
   ip_protocol = "UDP"
   port_range  = "4500-4500"
-  ip_address  = "${google_compute_address.gcp-vpn-ip.address}"
-  target      = "${google_compute_vpn_gateway.gcp-vpn-gw.self_link}"
+  ip_address  = google_compute_address.gcp-vpn-ip.address
+  target      = google_compute_vpn_gateway.gcp-vpn-gw.self_link
 }
 
 /*
@@ -75,45 +74,45 @@ resource "google_compute_forwarding_rule" "fr_udp4500" {
 
 resource "google_compute_vpn_tunnel" "gcp-tunnel1" {
   name          = "gcp-tunnel1"
-  peer_ip       = "${aws_vpn_connection.aws-vpn-connection1.tunnel1_address}"
-  shared_secret = "${aws_vpn_connection.aws-vpn-connection1.tunnel1_preshared_key}"
+  peer_ip       = aws_vpn_connection.aws-vpn-connection1.tunnel1_address
+  shared_secret = aws_vpn_connection.aws-vpn-connection1.tunnel1_preshared_key
   ike_version   = 1
 
-  target_vpn_gateway = "${google_compute_vpn_gateway.gcp-vpn-gw.self_link}"
+  target_vpn_gateway = google_compute_vpn_gateway.gcp-vpn-gw.self_link
 
-  router = "${google_compute_router.gcp-router1.name}"
+  router = google_compute_router.gcp-router1.name
 
   depends_on = [
-    "google_compute_forwarding_rule.fr_esp",
-    "google_compute_forwarding_rule.fr_udp500",
-    "google_compute_forwarding_rule.fr_udp4500",
+    google_compute_forwarding_rule.fr_esp,
+    google_compute_forwarding_rule.fr_udp500,
+    google_compute_forwarding_rule.fr_udp4500,
   ]
 }
 
 resource "google_compute_router" "gcp-router1" {
-  name = "gcp-router1"
-  region = "${var.gcp_region}"
-  network = "${google_compute_network.gcp-network.name}"
+  name    = "gcp-router1"
+  region  = var.gcp_region
+  network = google_compute_network.gcp-network.name
   bgp {
-    asn = "${aws_customer_gateway.aws-cgw.bgp_asn}"
+    asn = aws_customer_gateway.aws-cgw.bgp_asn
   }
 }
 
 resource "google_compute_router_peer" "gcp-router1-peer" {
-  name = "gcp-to-aws-bgp1"
-  router  = "${google_compute_router.gcp-router1.name}"
-  region  = "${google_compute_router.gcp-router1.region}"
-  peer_ip_address = "${aws_vpn_connection.aws-vpn-connection1.tunnel1_vgw_inside_address}"
-  peer_asn = "${var.GCP_TUN1_VPN_GW_ASN}"
-  interface = "${google_compute_router_interface.router_interface1.name}"
+  name            = "gcp-to-aws-bgp1"
+  router          = google_compute_router.gcp-router1.name
+  region          = google_compute_router.gcp-router1.region
+  peer_ip_address = aws_vpn_connection.aws-vpn-connection1.tunnel1_vgw_inside_address
+  peer_asn        = var.GCP_TUN1_VPN_GW_ASN
+  interface       = google_compute_router_interface.router_interface1.name
 }
 
 resource "google_compute_router_interface" "router_interface1" {
-  name    = "gcp-to-aws-interface1"
-  router  = "${google_compute_router.gcp-router1.name}"
-  region  = "${google_compute_router.gcp-router1.region}"
-  ip_range = "${aws_vpn_connection.aws-vpn-connection1.tunnel1_cgw_inside_address}/${var.GCP_TUN1_CUSTOMER_GW_INSIDE_NETWORK_CIDR}"
-  vpn_tunnel = "${google_compute_vpn_tunnel.gcp-tunnel1.name}"
+  name       = "gcp-to-aws-interface1"
+  router     = google_compute_router.gcp-router1.name
+  region     = google_compute_router.gcp-router1.region
+  ip_range   = "${aws_vpn_connection.aws-vpn-connection1.tunnel1_cgw_inside_address}/${var.GCP_TUN1_CUSTOMER_GW_INSIDE_NETWORK_CIDR}"
+  vpn_tunnel = google_compute_vpn_tunnel.gcp-tunnel1.name
 }
 
 /*
@@ -122,44 +121,44 @@ resource "google_compute_router_interface" "router_interface1" {
 
 resource "google_compute_vpn_tunnel" "gcp-tunnel2" {
   name          = "gcp-tunnel2"
-  peer_ip       = "${aws_vpn_connection.aws-vpn-connection1.tunnel2_address}"
-  shared_secret = "${aws_vpn_connection.aws-vpn-connection1.tunnel2_preshared_key}"
+  peer_ip       = aws_vpn_connection.aws-vpn-connection1.tunnel2_address
+  shared_secret = aws_vpn_connection.aws-vpn-connection1.tunnel2_preshared_key
   ike_version   = 1
 
-  target_vpn_gateway = "${google_compute_vpn_gateway.gcp-vpn-gw.self_link}"
+  target_vpn_gateway = google_compute_vpn_gateway.gcp-vpn-gw.self_link
 
-  router = "${google_compute_router.gcp-router2.name}"
+  router = google_compute_router.gcp-router2.name
 
   depends_on = [
-    "google_compute_forwarding_rule.fr_esp",
-    "google_compute_forwarding_rule.fr_udp500",
-    "google_compute_forwarding_rule.fr_udp4500",
+    google_compute_forwarding_rule.fr_esp,
+    google_compute_forwarding_rule.fr_udp500,
+    google_compute_forwarding_rule.fr_udp4500,
   ]
 }
 
 resource "google_compute_router" "gcp-router2" {
-  name = "gcp-router2"
-  region = "${var.gcp_region}"
-  network = "${google_compute_network.gcp-network.name}"
+  name    = "gcp-router2"
+  region  = var.gcp_region
+  network = google_compute_network.gcp-network.name
   bgp {
-    asn = "${aws_customer_gateway.aws-cgw.bgp_asn}"
+    asn = aws_customer_gateway.aws-cgw.bgp_asn
   }
 }
 
 resource "google_compute_router_peer" "gcp-router2-peer" {
-  name = "gcp-to-aws-bgp2"
-  router  = "${google_compute_router.gcp-router2.name}"
-  region  = "${google_compute_router.gcp-router2.region}"
-  peer_ip_address = "${aws_vpn_connection.aws-vpn-connection1.tunnel2_vgw_inside_address}"
-  peer_asn = "${var.GCP_TUN2_VPN_GW_ASN}"
-  interface = "${google_compute_router_interface.router_interface2.name}"
+  name            = "gcp-to-aws-bgp2"
+  router          = google_compute_router.gcp-router2.name
+  region          = google_compute_router.gcp-router2.region
+  peer_ip_address = aws_vpn_connection.aws-vpn-connection1.tunnel2_vgw_inside_address
+  peer_asn        = var.GCP_TUN2_VPN_GW_ASN
+  interface       = google_compute_router_interface.router_interface2.name
 }
-
 
 resource "google_compute_router_interface" "router_interface2" {
-  name    = "gcp-to-aws-interface2"
-  router  = "${google_compute_router.gcp-router2.name}"
-  region  = "${google_compute_router.gcp-router2.region}"
-  ip_range = "${aws_vpn_connection.aws-vpn-connection1.tunnel2_cgw_inside_address}/${var.GCP_TUN2_CUSTOMER_GW_INSIDE_NETWORK_CIDR}"
-  vpn_tunnel = "${google_compute_vpn_tunnel.gcp-tunnel2.name}"
+  name       = "gcp-to-aws-interface2"
+  router     = google_compute_router.gcp-router2.name
+  region     = google_compute_router.gcp-router2.region
+  ip_range   = "${aws_vpn_connection.aws-vpn-connection1.tunnel2_cgw_inside_address}/${var.GCP_TUN2_CUSTOMER_GW_INSIDE_NETWORK_CIDR}"
+  vpn_tunnel = google_compute_vpn_tunnel.gcp-tunnel2.name
 }
+

--- a/terraform/gcp_outputs.tf
+++ b/terraform/gcp_outputs.tf
@@ -14,17 +14,18 @@
  * limitations under the License.
  */
 
-
 /*
  * Terraform output variables for GCP.
  */
 
 output "gcp_instance_external_ip" {
   value = <<-EOF
-  ${google_compute_instance.gcp-vm.network_interface.0.access_config.0.nat_ip}
-  EOF
+  ${google_compute_instance.gcp-vm.network_interface[0].access_config[0].nat_ip}
+EOF
+
 }
 
 output "gcp_instance_internal_ip" {
-  value = "${google_compute_instance.gcp-vm.network_interface.0.network_ip}"
+  value = google_compute_instance.gcp-vm.network_interface[0].network_ip
 }
+

--- a/terraform/gcp_security.tf
+++ b/terraform/gcp_security.tf
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 /*
  * Terraform security (firewall) resources for GCP.
  */
@@ -22,63 +21,64 @@
 # Allow PING testing.
 resource "google_compute_firewall" "gcp-allow-icmp" {
   name    = "${google_compute_network.gcp-network.name}-gcp-allow-icmp"
-  network = "${google_compute_network.gcp-network.name}"
+  network = google_compute_network.gcp-network.name
 
   allow {
     protocol = "icmp"
   }
 
   source_ranges = [
-    "0.0.0.0/0"
+    "0.0.0.0/0",
   ]
 }
 
 # Allow SSH for iperf testing.
 resource "google_compute_firewall" "gcp-allow-ssh" {
   name    = "${google_compute_network.gcp-network.name}-gcp-allow-ssh"
-  network = "${google_compute_network.gcp-network.name}"
+  network = google_compute_network.gcp-network.name
 
   allow {
     protocol = "tcp"
-    ports = ["22"]
+    ports    = ["22"]
   }
 
   source_ranges = [
-    "0.0.0.0/0"
+    "0.0.0.0/0",
   ]
 }
 
 # Allow traffic from the VPN subnets.
 resource "google_compute_firewall" "gcp-allow-vpn" {
   name    = "${google_compute_network.gcp-network.name}-gcp-allow-vpn"
-  network = "${google_compute_network.gcp-network.name}"
+  network = google_compute_network.gcp-network.name
 
   allow {
     protocol = "tcp"
-    ports = ["0-65535"]
+    ports    = ["0-65535"]
   }
 
   allow {
     protocol = "udp"
-    ports = ["0-65535"]
+    ports    = ["0-65535"]
   }
 
   source_ranges = [
-    "${var.aws_subnet1_cidr}"
+    var.aws_subnet1_cidr,
   ]
 }
 
 # Allow TCP traffic from the Internet.
 resource "google_compute_firewall" "gcp-allow-internet" {
   name    = "${google_compute_network.gcp-network.name}-gcp-allow-internet"
-  network = "${google_compute_network.gcp-network.name}"
+  network = google_compute_network.gcp-network.name
 
   allow {
     protocol = "tcp"
-    ports = ["80"]
+    ports    = ["80"]
   }
 
   source_ranges = [
-    "0.0.0.0/0"
+    "0.0.0.0/0",
   ]
 }
+

--- a/terraform/gcp_variables.tf
+++ b/terraform/gcp_variables.tf
@@ -14,65 +14,65 @@
  * limitations under the License.
  */
 
-
 /*
  * Terraform variable declarations for GCP.
  */
 
-variable gcp_credentials_file_path {
+variable "gcp_credentials_file_path" {
   description = "Locate the GCP credentials .json file."
-  type = "string"
+  type        = string
 }
 
 variable "gcp_project_id" {
   description = "GCP Project ID."
-  type = "string"
+  type        = string
 }
 
-variable gcp_region {
+variable "gcp_region" {
   description = "Default to Oregon region."
-  default = "us-west1"
+  default     = "us-west1"
 }
 
-variable gcp_instance_type {
+variable "gcp_instance_type" {
   description = "Machine Type. Correlates to an network egress cap."
-  default = "n1-highmem-8"
+  default     = "n1-highmem-8"
 }
 
-variable gcp_disk_image {
+variable "gcp_disk_image" {
   description = "Boot disk for gcp_instance_type."
-  default = "projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts"
+  default     = "projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts"
 }
 
-variable gcp_network_cidr {
+variable "gcp_network_cidr" {
   default = "10.240.0.0/16"
 }
 
-variable gcp_subnet1_cidr {
+variable "gcp_subnet1_cidr" {
   default = "10.240.0.0/24"
 }
 
-variable gcp_vm_address {
+variable "gcp_vm_address" {
   description = "Private IP address for GCP VM instance."
-  default = "10.240.0.100"
+  default     = "10.240.0.100"
 }
 
-variable GCP_TUN1_VPN_GW_ASN {
+variable "GCP_TUN1_VPN_GW_ASN" {
   description = "Tunnel 1 - Virtual Private Gateway ASN, from the AWS VPN Customer Gateway Configuration"
-  default = "64512"
+  default     = "64512"
 }
 
-variable GCP_TUN1_CUSTOMER_GW_INSIDE_NETWORK_CIDR {
+variable "GCP_TUN1_CUSTOMER_GW_INSIDE_NETWORK_CIDR" {
   description = "Tunnel 1 - Customer Gateway from Inside IP Address CIDR block, from AWS VPN Customer Gateway Configuration"
-  default = "30"
+  default     = "30"
 }
 
-variable GCP_TUN2_VPN_GW_ASN {
+variable "GCP_TUN2_VPN_GW_ASN" {
   description = "Tunnel 2 - Virtual Private Gateway ASN, from the AWS VPN Customer Gateway Configuration"
-  default = "64512"
+  default     = "64512"
 }
 
-variable GCP_TUN2_CUSTOMER_GW_INSIDE_NETWORK_CIDR {
+variable "GCP_TUN2_CUSTOMER_GW_INSIDE_NETWORK_CIDR" {
   description = "Tunnel 2 - Customer Gateway from Inside IP Address CIDR block, from AWS VPN Customer Gateway Configuration"
-  default = "30"
+  default     = "30"
 }
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -14,28 +14,27 @@
  * limitations under the License.
  */
 
-
 /*
  * Terraform main configuration file (with provider definitions).
  */
 
 provider "google" {
-  version = "~> 2.11.0"
+  version = "~> 3.19.0"
 
-  credentials = "${file("${var.gcp_credentials_file_path}")}"
+  credentials = file(var.gcp_credentials_file_path)
 
   # Should be able to parse project from credentials file but cannot.
   # Cannot convert string to map and cannot interpolate within variables.
-  project = "${var.gcp_project_id}"
+  project = var.gcp_project_id
 
-  region = "${var.gcp_region}"
+  region = var.gcp_region
 }
-
 
 provider "aws" {
-  version = "~> 2.19.0"
+  version = "~> 2.60.0"
 
-  shared_credentials_file = "${pathexpand("${var.aws_credentials_file_path}")}"
+  shared_credentials_file = pathexpand(var.aws_credentials_file_path)
 
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
+


### PR DESCRIPTION
- The current code fails when run with Terraform 0.12 (That is also the version installed by get_terraform.sh script) 
- These files are updated using "terraform 0.12upgrade" command. 
- This commit also has newer versions of Google and AWS providers. 
- I have tested the whole workflow after this change and it works as expected.
