### PR TITLE
fix detecting aws key and secret

### DIFF
--- a/aws_set_credentials.sh
+++ b/aws_set_credentials.sh
@@ -69,8 +69,8 @@ function addDefault() {
 # Add AWS secrets.
 # arguments: source_keys_file credentials_file
 function addSecrets() {
-  local KEY_ID=$(tail -1 "$1" | cut -d"," -f1)
-  local SECRET_KEY=$(tail -1 "$1" | cut -d"," -f2)
+  local KEY_ID=$(tail -1 "$1" | cut -d"," -f3)
+  local SECRET_KEY=$(tail -1 "$1" | cut -d"," -f4)
 
   echo "aws_access_key_id=${KEY_ID}" >> $2
   echo "aws_secret_access_key=${SECRET_KEY}" >> $2


### PR DESCRIPTION
Now the AWS credential csv file format is:
```csv
User name,Password,Access key ID,Secret access key,Console login link
user,pass,xxxxxx,xxxxxxxxxxxxxxx,https://nnnnnnnnnnnnnn.signin.aws.amazon.com/console
```

So credentials should be picked up with the 3rd and 4th column.

ref: [Automated Network Deployment](https://cloud.google.com/solutions/automated-network-deployment-overview?hl=en)